### PR TITLE
Implement Gabriel fallback damage

### DIFF
--- a/src/constants/intercessions.ts
+++ b/src/constants/intercessions.ts
@@ -28,7 +28,7 @@ export const INTERCESSION_DEFINITIONS: Record<IntercessionsType, Omit<Intercessi
   GABRIEL: {
     type: 'GABRIEL',
     name: 'Insight of Gabriel',
-    description: 'Automatically plays your highest-scoring possible word.',
+    description: 'Automatically plays your highest-scoring possible word, or deals 30 damage if no word is found.',
     cooldown: 5
   },
   METATRON: {

--- a/src/events/gameEvents.ts
+++ b/src/events/gameEvents.ts
@@ -909,7 +909,7 @@ export function registerGameEvents(socket: Socket, io: Server) {
       }
 
       // Execute the intercession through GameService (now async)
-      const result = await gameService.executeIntercession(context.roomId, context.player.id, data.intercessionId);
+      const result = await gameService.executeIntercession(context.roomId, context.player.id, data.intercessionId, io);
       
       socket.emit('activate-intercession-response', {
         success: result.success,


### PR DESCRIPTION
## Summary
- allow `executeIntercession` to pass socket.io instance
- send fallback damage when Gabriel fails to find a word
- update Gabriel's intercession description
- wire `activate-intercession` event to pass socket.io instance

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851b4ab8e348333a4c262a1e99c6d03