### PR TITLE
Implement intercession selection flow

### DIFF
--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -7,6 +7,7 @@ export interface Room {
   players: RoomPlayer[];
   gameState?: GameState;
   isStarted: boolean;
+  intercessionSelectionStarted: boolean;
   createdAt: Date;
   maxPlayers: number;
 }
@@ -43,5 +44,6 @@ export interface RoomInfo {
   hostId: string;
   players: RoomPlayer[];
   isStarted: boolean;
+  intercessionSelectionStarted: boolean;
   maxPlayers: number;
 }


### PR DESCRIPTION
## Summary
- track whether intercession selection phase has begun in room types
- set `intercessionSelectionStarted` when creating rooms
- handle intercession checks when starting games
- auto start game when all intercessions are selected
- notify clients about intercession selection starting and game start

## Testing
- `npm run build` *(fails: Cannot find module 'socket.io')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851bc5332dc833385b617a658d015f1